### PR TITLE
Enable Ubuntu 22.04 server vagrant testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,7 @@ jobs:
           - fedora-latest
           - ubuntu-1804
           - ubuntu-2004
-          # Disabled due to ssh key issues with vagrant
-          # - ubuntu-2204
+          - ubuntu-2204
         suite:
           - server
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the nfs cookbook.
 
 ## Unreleased
 
+- Enable Ubuntu 22.04 server vagrant testing
+
 ## 5.0.1 - *2022-12-20*
 
 - Add support for Ubuntu 22.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,6 +12,12 @@ provisioner:
   deprecations_as_errors: true
   chef_license: accept-no-persist
 
+# TODO(ramereth): Remove on the next release of chef-workstation - 12/20/2022
+transport:
+  name: ssh
+  username: vagrant
+  password: vagrant
+
 verifier:
   name: inspec
 


### PR DESCRIPTION
Force to using user/password work around ssh key problems.

Signed-off-by: Lance Albertson <lance@osuosl.org>
